### PR TITLE
[account_amortization_common] 8.0.2.3.1

### DIFF
--- a/account_amortization_common/__openerp__.py
+++ b/account_amortization_common/__openerp__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Common Amortization Feature",
-    "version": "8.0.2.3.0",
+    "version": "8.0.2.3.1",
     "category": "Accounting",
     "website": "https://simetri-sinergi.id",
     "author": "PT. Simetri Sinergi Indonesia, OpenSynergy Indonesia",

--- a/account_amortization_common/models/account_amortization_common.py
+++ b/account_amortization_common/models/account_amortization_common.py
@@ -468,10 +468,11 @@ class AccountAmortizationCommon(models.AbstractModel):
         "date_start",
     )
     def constrains_date_start(self):
-        if self.move_line_id and self.date_start:
-            if self.move_line_id.date > self.date_start:
-                msg = _("Date start has to be greater than effective date")
-                raise UserError(msg)
+        msg = _("Date start has to be greater than effective date")
+        for record in self:
+            if record.date and record.date_start:
+                if record.date > record.date_start:
+                    raise UserError(msg)
 
     @api.constrains(
         "move_line_id",


### PR DESCRIPTION
* Use date for constrains instead of move_line_id.date